### PR TITLE
Added support for custom and alternative formats

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,8 @@
 # Insert Time Stamp
 Quick insertion of unix-shell-like time stamp into Visual Studio Code editor
 
-## Example
+## Example of default primary format
+
 ```
 ###### Sun Sep 18 15:29:29 IDT 2016
 ```
@@ -9,59 +10,81 @@ Quick insertion of unix-shell-like time stamp into Visual Studio Code editor
 Here is how it looks after markdown processing:
 ###### Sun Sep 18 15:29:29 IDT 2016
 
-## Install (see on [Market Place](https://marketplace.visualstudio.com/items?itemName=zvlad.inserttimestamp)) 
+## Install (see on [Market Place](https://marketplace.visualstudio.com/items?itemName=zvlad.inserttimestamp))
+
 There are 2 options to install the extention
 1. via VSCode UI
     * launch VS Code Quick Open (Ctrl+P)
-    * execute the following command  
+    * execute the following command
         `ext install inserttimestamp`
     * hit green "Install" button next to **Insert Time Stamp** item in VSCode sidebar.
 
 1. via system command line
-    * in your terminal run the following command  
+    * in your terminal run the following command
         `code --install-extension zvlad.inserttimestamp`
 
 ## Uninstall
+
 There are 2 options to uninstall the extention
 1. via VSCode UI
     * open `Extensions` tab in the VS Code sidebar
     * hit "Uninstall" next to **Insert Time Stamp** item.
 
 1. via system command line
-    * in your terminal run the following command  
+    * in your terminal run the following command
         `code --uninstall-extension zvlad.inserttimestamp`
 
 ## Configure shortcuts
-Default shortcut is `ctrl + f5`  
 
-in your `Code/User/keybindings.json` file add the following:
-```
+The default shortcut for the primary timestamp is `Ctrl+F5`. The default shortcut for the alternative timestamp is `Ctrl+Shift+F5`.
+
+In your `Code/User/keybindings.json` file add the following:
+
+```json
 {
     "key": "ctrl+f5", // specify shortcut you like here
     "command": "inserttimestamp.perform",
+    "when": "editorTextFocus"
+}, {
+    "key": "ctrl+shift+f5", // specify shortcut you like here
+    "command": "inserttimestamp.alternative",
     "when": "editorTextFocus"
 }
 ```
 
 ## Format
-Currently supported timestamp format: `###### Www Mmm dd h:mm:ss Tz yyyy`  
 
-where:  
-    `######` — prefix (as is: "######")  
-    `Www` — week day name (3 letters)  
-    `Mmm` — month name (3 letters)  
-    `dd` — day in month  
-    `h` — hours (24h format)  
-    `mm` — minutes  
-    `ss` — seconds  
-    `Tz` — Time zone abbreviation (3 letters, I am not sure if it is true for any time zone)   
-    `yyyy` — year (4 digits)
+The timestamp format can be configured in `settings.json` as in the following examples:
+
+```json
+"inserttimestamp.format": "YYYY-MM-DD",
+"inserttimestamp.alternative": "YYYY-MM-DDTHH:mm:ssZ"
+```
+
+Where the format strings are interpreted by [moment.js](https://momentjs.com/docs/#/displaying/format/). For example, the format string `"X"` is the unix timestamp in seconds, and a format of `null` will produce an ISO 8601 string.
+
+The `format` setting is used for the primary entry (`Ctrl+F5`), while the `alternative` setting is used for the alternative entry (`Ctrl+Shift+F5`). A typical use case for this might be to have separate date and time entries, or a long and short date.
+
+If the settings are left blank, the `alternative` setting defaults to the ISO 8601 format, while the primary format defaults to something like "`###### ddd MMM DD k:mm:ss zz YYYY`", where:
+
+    `######` — prefix (as is: "######")
+    `ddd` — week day name (3 letters)
+    `MMM` — month name (3 letters)
+    `DD` — day in month
+    `k` — hours (24h format)
+    `mm` — minutes
+    `ss` — seconds
+    `zz` — Time zone abbreviation (3 letters, I am not sure if it is true for any time zone)
+    `YYYY` — year (4 digits)
 
 ## License
 Extension licensed under [MIT](./LICENSE)
 
 ## Author
-[Vlad Zamskoi](https://www.freeraven.com/ "Developer website")
+[Vlad Zamskoi](https://www.freeraven.com/)
 
 ## Thanks
+
 To [Nick Roach](https://www.elegantthemes.com/) for the great icon.
+
+To [Michael Hunter](http://coder-mike.com) for adding support for custom and alternative formats.

--- a/package.json
+++ b/package.json
@@ -1,8 +1,8 @@
 {
   "name": "inserttimestamp",
   "displayName": "Insert Time Stamp",
-  "description": "Insert unix-shell-like date and time to current editor.",
-  "version": "1.1.3",
+  "description": "Insert date and time to current editor.",
+  "version": "1.2.0",
   "publisher": "zvlad",
   "engines": {
     "vscode": "^1.5.0"
@@ -12,14 +12,18 @@
     "Other"
   ],
   "activationEvents": [
-    "onCommand:inserttimestamp.perform"
+    "onCommand:inserttimestamp.perform",
+    "onCommand:inserttimestamp.alternative"
   ],
   "main": "./out/src/extension",
   "contributes": {
     "commands": [
       {
         "command": "inserttimestamp.perform",
-        "title": "Insert Time Stamp"
+        "title": "Insert timestamp"
+      }, {
+        "command": "inserttimestamp.alternative",
+        "title": "Insert timestamp using the alternative format configuration string"
       }
     ],
     "keybindings": [
@@ -28,8 +32,29 @@
         "key": "ctrl+f5",
         "mac": "cmd+f5",
         "when": "editorTextFocus"
+      }, {
+        "command": "inserttimestamp.alternative",
+        "key": "ctrl+shift+f5",
+        "mac": "cmd+shift+f5",
+        "when": "editorTextFocus"
       }
-    ]
+    ],
+    "configuration": {
+      "type": "object",
+      "title": "Insert Timestamp configuration",
+      "properties": {
+        "inserttimestamp.format": {
+          "type": "string",
+          "default": false,
+          "description": "A moment.js compatible date/time format string"
+        },
+        "inserttimestamp.alternative": {
+          "type": "string",
+          "default": null,
+          "description": "A moment.js compatible date/time format string, used for the alternative insertion command"
+        }
+      }
+    }
   },
   "scripts": {
     "vscode:prepublish": "node ./node_modules/vscode/bin/compile",
@@ -41,6 +66,7 @@
     "vscode": "^0.11.0"
   },
   "dependencies": {
+    "moment": "^2.17.1",
     "moment-timezone": "^0.5.5"
   },
   "keywords": [


### PR DESCRIPTION
I've added support for customizing the format using settings.json. The format feeds directly into moment.js's format function, and so off the bat it comes with all of moment.js's formatting options. One such option is 'X' or 'x' for Unix seconds and milliseconds respectively, which satisfies feature request [issue 1](https://github.com/jvlad/InsertTimeStamp.vscode.ts/issues/1).

The user can define up to 2 custom formats, one that is triggered with the default key `Ctrl+F5`, and the other with `Ctrl+Shift+F5`. For example, this allows someone to have a short date and a long date, or a date and a time, etc. For me personally, I use timestamps liberally in my "lab notes" (e.g. notes I take while I'm debugging a challenging issue) and sometimes I need a timestamp with a date-and-time and sometimes only a time (depending on what is obvious from context).